### PR TITLE
Adding DatePicker to OM MaterialUI Components

### DIFF
--- a/src/om_material_ui/core.cljx
+++ b/src/om_material_ui/core.cljx
@@ -12,6 +12,7 @@
   AppCanvas
   Circle
   Checkbox  
+  DatePicker
   DialogWindow
   Dialog
   DropDownIcon


### PR DESCRIPTION
The [DatePicker](http://material-ui.com/#/components/date-picker) is working, and also available as an Om MaterialUI component. 
