### PR TITLE
README text how to access component methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@ Then going to resources/public/index.html in a browser
 
 You should see a very basic input box, material ui-style.
 
+### Accessing component methods
+
+Most material-ui react components have methods to control their behaviour. For example, [TextField](http://material-ui.com/#/components/text-fields) has `getValue()` to retrieve its value (amongst others). To access these you must get the raw react component.
+
+Using the folowing function, the raw react component can be retrieved using `:ref`:
+
+```clojure
+(defn get-ref [owner ref]
+  (aget (.-refs owner) ref))
+```
+
+Then, given this text field component:
+
+```clojure
+(mui/text-field
+  {:ref "text"})
+```
+
+You can get its value using `(.getValue (get-ref owner "text"))`
+
+
 ## License
 
 Copyright © 2015 FIXME


### PR DESCRIPTION
Added text to the readme explaining how material-ui react component methods can be accessed through the use of :ref
